### PR TITLE
adtify.pl fix

### DIFF
--- a/adblock_polska.txt
+++ b/adblock_polska.txt
@@ -184,7 +184,6 @@ _res/banner/glowna/
 ||adsearch.pl
 ||adstat.4u.pl
 ||adtaily.pl
-||adtify.pl
 ||adv.wp.pl
 ||adview.pl
 ||atmcdn.pl/*Adserver/
@@ -218,6 +217,7 @@ _res/banner/glowna/
 ||napisy24.pl/files/*
 ||napisy24.pl/images/190x260x_
 ||nextclick.pl
+||panel.adtify.pl
 ||pclab.pl/img/extra/*_top.png
 ||pclab.pl/img/extra/*_left.jpg
 ||pclab.pl/img/extra/*_right.jpg


### PR DESCRIPTION
Adtify.pl seems to have only marketing materials, ads seems to be served
from panel.adtify.pl domain. Blocking whole adtify.pl breaks things like
adtify.pl/odbierz100pln and others; blacklisting only panel.adtify.pl
is still blocking the ads while leaving site with marketing materials as
it was intended to be.

![2014-05-17-123104_1920x975_scrot](https://cloud.githubusercontent.com/assets/1618371/3004687/94a4f44e-ddb1-11e3-8fc7-3ec11afbbc6b.png)
